### PR TITLE
開始時間と終了時間が入力されていない時にエラーがでるため修正

### DIFF
--- a/app/controllers/user/event_controller.rb
+++ b/app/controllers/user/event_controller.rb
@@ -21,6 +21,12 @@ class User::EventController < ApplicationController
       load_genres_and_subgenres
       render :new, status: :unprocessable_entity and return
     end
+
+    if @event.start_time.blank? || @event.end_time.blank?
+      @event.errors.add(:start_time, '開始時間と終了時間を入力してください')
+      load_genres_and_subgenres
+      render :new, status: :unprocessable_entity and return
+    end
   
     if @event.start_time > @event.end_time
       @event.errors.add(:end_time, "終了時間は開始時間より後である必要があります")


### PR DESCRIPTION
- 開始時間と終了時間が入力されていない時に、
`
@event.start_time > @event.end_time`

上記のような比較が行われて、両者とも何も入っていないくエラーがでるため、
開始時間と終了時間を比較する前に値が入っているかどうかの確認を追加。

※モデルに開始時間より終了時間が早い時にエラーを出すコードを実装しようと考えましたが、どうも作成時にエラーがでずに作成されるために、一時的にコントローラーに値のチェックをしています。