### PR TITLE
Takahashi/matching algorithm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "sqlite3",         "1.6.1"
 gem "devise"
 gem 'enum_help'
 gem 'rails-i18n'
+gem 'geocoder'
 
 group :development, :test do
   gem "debug",   "1.7.1", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     ansi (1.5.0)
     ast (2.4.2)
     backport (1.2.0)
+    base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.3.0)
     bindex (0.8.1)
@@ -89,6 +90,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    csv (3.3.2)
     date (3.3.3)
     debug (1.7.1)
       irb (>= 1.5.0)
@@ -108,6 +110,9 @@ GEM
     erubi (1.12.0)
     ffi (1.15.5)
     formatador (1.1.0)
+    geocoder (1.8.5)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
     guard (2.18.0)
@@ -356,6 +361,7 @@ DEPENDENCIES
   devise
   dockerfile-rails (>= 1.6)
   enum_help
+  geocoder
   guard (= 2.18.0)
   guard-minitest (= 2.4.6)
   importmap-rails (= 1.1.5)

--- a/app/controllers/user/event_controller.rb
+++ b/app/controllers/user/event_controller.rb
@@ -34,6 +34,12 @@ class User::EventController < ApplicationController
       load_genres_and_subgenres
       render :new, status: :unprocessable_entity and return
     end
+
+    if @event.unmatched_age_min.present? && @event.unmatched_age_max.present? && @event.unmatched_age_min > @event.unmatched_age_max
+      @event.errors.add(:unmatched_age_max, " マッチングを希望しない年齢の上限は下限以上である必要があります")
+      load_genres_and_subgenres
+      render :new, status: :unprocessable_entity and return
+    end
   
     if @event.save
       # マッチングのアルゴリズムを実装する

--- a/app/controllers/user/event_controller.rb
+++ b/app/controllers/user/event_controller.rb
@@ -29,6 +29,8 @@ class User::EventController < ApplicationController
     end
   
     if @event.save
+      # マッチングのアルゴリズムを実装する
+      match_event(@event)
       redirect_to user_event_path(@event), notice: 'イベントの登録に成功しました。', turbo: false
     else
       load_genres_and_subgenres
@@ -60,6 +62,38 @@ class User::EventController < ApplicationController
     params.require(:event).permit(
       :address, :latitude, :longitude, :start_time, :end_time, :comment, :people_count, :position,:genre_id, :subgenre_id, :user_id, :unmetched_gender, :unmatched_age_min, :unmatched_age_max, :is_matched, :is_accepted
     )
+  end
+
+  # マッチングのアルゴリズムの内容
+  def match_event(new_event)
+    # すでにマッチングしていないEventかつ、今の時間よりも開始時間が後のものかつ、自分以外のユーザーが作成したイベントを抽出する
+    matching_events = Event.where(matched_id: nil).where("start_time > ?", Time.current).where.not(user_id: current_user.id)
+    # サブジャンルが一致するイベントを優先
+    matching_events = matching_events.where(genre_id: new_event.genre_id).where(sub_genre_id: new_event.sub_genre_id)
+    matching_events = mathing_events.where(genre_id: new_event.genre_id) if matching_events.empty?
+
+    # 時間でまず絞り込む
+    matching_events = matching_events.where("start_time <= ? AND end_time >= ?", new_event.end_time, new_event.start_time)
+
+    # 位置情報でさらに絞り込む（Geocoderを利用）
+    matching_events = matching_events.near([new_event.latitude, new_event.longitude], 10, units: :km)
+
+    # 残りのイベントをRuby側で絞り込む（もし必要なら）
+    matching_events = matching_events.select do |event|
+      is_time_overlap = event.start_time <= new_event.end_time && new_event.start_time <= event.end_time
+      is_time_overlap
+    end
+    # 条件に合致するか
+     
+    # 最も近いイベントを選択する
+    best_match_event = mathing.events.min_by(&:start_time)
+    if best_match_event
+      new_event.update(matched_id: new_event.event_id)
+      best_match_event.update(matched_event: new_event.event_id)
+    else 
+      # マッチングするイベントが見つからなかった場合
+      flash[:notice] = "マッチングするまでお待ちください"
+    end
   end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,7 +3,13 @@ class Event < ApplicationRecord
   belongs_to :user
   belongs_to :matched_event, class_name: 'Event', foreign_key: 'matched_id', optional: true
   has_many :matching_events, class_name: 'Event', foreign_key: 'matched_id'
-
+  before_create :set_remaining_people
 
   validates :address, :latitude, :longitude, :start_time, :end_time, :subgenre_id, :people_count, presence: true
+
+  private
+
+  def set_remaining_people
+    self.remaining_people = people_count - 1 
+  end
 end

--- a/app/views/user/event/index.html.erb
+++ b/app/views/user/event/index.html.erb
@@ -41,14 +41,16 @@
                 <p><strong>参加募集人数:</strong> <%= event.people_count %> 人</p>
                 <p><strong>希望ポジション:</strong> <%= event.position %></p>
                 <p><strong>サブジャンル:</strong> <%= event.subgenre.name %></p>
-                <% if  event.unmetched_gender == 1 %>
-                  <% gender = "男性" %>
+                <p><strong>希望しない性別:</strong> 
+                <% if  event.unmetched_gender == 0 %>
+                  その他
+                <%  elsif event.unmetched_gender == 1 %>
+                  男性
                 <%  elsif event.unmetched_gender == 2 %>
-                  <% gender = "女性" %>
+                  女性
                 <% else %>
-                  <% gender = "選択なし" %>
-                <% end %>
-                <p><strong>希望しない性別:</strong> <%= gender %></p>
+                  選択なし
+                <% end %></p>
                 <p><strong>希望しない年齢:</strong> <%= event.unmatched_age_min %>歳 ～ <%= event.unmatched_age_max %>歳</p>
                 <p><strong>承認状況:</strong> <%= event.is_accepted ? '✔ 承認済み' : '⏳ 未承認' %></p>
               </div>

--- a/app/views/user/event/new.html.erb
+++ b/app/views/user/event/new.html.erb
@@ -65,6 +65,21 @@
       <%= form.select :people_count, options_for_select((2..4).map { |n| [n.to_s, n] }), { prompt: '人数を選択してください' }, id: 'people_count' %>
     </div>
 
+    <div id="unmatched_gender_div" style="display: none;">
+      <%= form.label :unmatched_gender, "マッチングを希望しない性別（任意）" %>
+      <%= form.select :unmatched_gender, options_for_select([['その他', nil], ['男性', 'male'], ['女性', 'female']]), { prompt: 'マッチングを希望しない性別を選択してください' }, id: 'unmatched_gender' %>
+    </div>
+
+    <div id="unmatched_age_min_div" style="display: none;">
+      <%= form.label :unmatched_age_min, "年齢の下限（任意）" %>
+      <%= form.number_field :unmatched_age_min, id: 'unmatched_age_min', placeholder: '年齢の下限を入力してください' %>
+    </div>
+
+    <div id="unmatched_age_max_div" style="display: none;">
+      <%= form.label :unmatched_age_max, "年齢の上限（任意）" %>
+      <%= form.number_field :unmatched_age_max, id: 'unmatched_age_max', placeholder: '年齢の上限を入力してください' %>
+    </div>
+
     <div>
       <%= form.label :position, "自分の行いたい役割" %>
       <%= form.text_field :position, id: 'position', placeholder: '例: ピッチャー' %>
@@ -201,7 +216,31 @@
     attachGenreChangeEventListener();
     updateSubgenreFromInitialState();
   });
+  // people_countが2に選ばれたときに任意の質問（性別や年齢に関する質問）を表示する
+  document.addEventListener('DOMContentLoaded', function () {
+  const peopleCountSelect = document.getElementById('people_count');
+  const unmatchedGenderDiv = document.getElementById('unmatched_gender_div');
+  const unmatchedAgeMinDiv = document.getElementById('unmatched_age_min_div');
+  const unmatchedAgeMaxDiv = document.getElementById('unmatched_age_max_div');
 
+  // 初期状態で表示・非表示の設定
+  toggleMatchingQuestions();
+
+  // people_countが変更された時にトグルする
+  peopleCountSelect.addEventListener('change', toggleMatchingQuestions);
+
+  function toggleMatchingQuestions() {
+    if (peopleCountSelect.value == '2') {
+      unmatchedGenderDiv.style.display = 'block';
+      unmatchedAgeMinDiv.style.display = 'block';
+      unmatchedAgeMaxDiv.style.display = 'block';
+    } else {
+      unmatchedGenderDiv.style.display = 'none';
+      unmatchedAgeMinDiv.style.display = 'none';
+      unmatchedAgeMaxDiv.style.display = 'none';
+    }
+  }
+});
 
 </script>
 

--- a/app/views/user/event/new.html.erb
+++ b/app/views/user/event/new.html.erb
@@ -65,9 +65,12 @@
       <%= form.select :people_count, options_for_select((2..4).map { |n| [n.to_s, n] }), { prompt: '人数を選択してください' }, id: 'people_count' %>
     </div>
 
-    <div id="unmatched_gender_div" style="display: none;">
-      <%= form.label :unmatched_gender, "マッチングを希望しない性別（任意）" %>
-      <%= form.select :unmatched_gender, options_for_select([['その他', nil], ['男性', 'male'], ['女性', 'female']]), { prompt: 'マッチングを希望しない性別を選択してください' }, id: 'unmatched_gender' %>
+    <div id="unmetched_gender_div" style="display: none;">
+      <%= form.label :unmetched_gender, "マッチングを希望しない性別（任意）" %>
+    <%= form.select :unmetched_gender, 
+    [[ "その他", 0 ], [ "男性", 1 ], [ "女性", 2 ]], 
+    { include_blank: "マッチングを希望しない性別を選択してください" }, 
+    id: "unmetched_gender" %>      
     </div>
 
     <div id="unmatched_age_min_div" style="display: none;">
@@ -219,7 +222,7 @@
   // people_countが2に選ばれたときに任意の質問（性別や年齢に関する質問）を表示する
   document.addEventListener('DOMContentLoaded', function () {
   const peopleCountSelect = document.getElementById('people_count');
-  const unmatchedGenderDiv = document.getElementById('unmatched_gender_div');
+  const unmatchedGenderDiv = document.getElementById('unmetched_gender_div');
   const unmatchedAgeMinDiv = document.getElementById('unmatched_age_min_div');
   const unmatchedAgeMaxDiv = document.getElementById('unmatched_age_max_div');
 

--- a/config/initializers/geocorder.rb
+++ b/config/initializers/geocorder.rb
@@ -1,0 +1,3 @@
+Geocoder.configure(
+  units: :km
+)

--- a/db/migrate/20241221133342_add_remaining_people_to_events.rb
+++ b/db/migrate/20241221133342_add_remaining_people_to_events.rb
@@ -1,0 +1,5 @@
+class AddRemainingPeopleToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :remaining_people, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_21_090708) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_21_133342) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -57,6 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_21_090708) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "matched_id"
+    t.integer "remaining_people"
     t.index ["matched_id"], name: "index_events_on_matched_id"
     t.index ["subgenre_id"], name: "index_events_on_subgenre_id"
     t.index ["user_id"], name: "index_events_on_user_id"


### PR DESCRIPTION
- 簡易的なマッチングの実装
- マッチングのミニマル版です。出来るかどうか試してみてください
↓
- 4人でも正しくマッチングすることが出来るようになりました
- Eventにremaining_peopleというカラムを追加し、現在の募集人数を管理します 
- 希望しない性別や年齢について、フォームをイベント作成のページに追加
- 自分を含めて募集人数が2人のときのみ、希望しない性別や年齢を考慮したマッチングを実装
- イベントの結果一覧のところの希望しない性別の表示を修正しました